### PR TITLE
Make `context` parameter in `deriveProof` optional and add a default value for the VP context

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -228,7 +228,6 @@ export const blindVerify = async (
  * Derives a Verifiable Presentation (VP) from a set of Verifiable Credential (VC) pairs using a given set of public keys, context, and document loader.
  * @param vcPairs The array of Verifiable Credential (VC) pairs, where each pair is an array of two VCs: the original VC and the partially-anonymized VC.
  * @param publicKeys The public keys used for deriving the proof.
- * @param context The JSON-LD context definition.
  * @param documentLoader The document loader used for resolving JSON-LD documents.
  * @param options (Optional) Additional options for deriving the proof.
  * @returns A Promise that resolves to the derived proof as a JSON-LD document.
@@ -236,7 +235,6 @@ export const blindVerify = async (
 export const deriveProof = async (
   vcPairs: VCPair[],
   publicKeys: jsonld.JsonLdDocument,
-  context: jsonld.ContextDefinition,
   documentLoader: DocumentLoader,
   options?: DeriveProofOptions,
 ): Promise<jsonld.JsonLdDocument> => {
@@ -266,7 +264,7 @@ export const deriveProof = async (
     circuits: options?.circuits,
   });
 
-  const jsonldVP = await jsonldVPFromRDF(vp, context, documentLoader);
+  const jsonldVP = await jsonldVPFromRDF(vp, documentLoader, options?.context);
 
   return jsonldVP;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,10 +50,13 @@ export interface JsonObject {
   [key: string]: JsonValue;
 }
 export type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+type OrArray<T> = T | T[];
+export type JsonLdContextHeader = OrArray<string | jsonld.ContextDefinition>;
 
 export type DocumentLoader = (url: Url) => Promise<RemoteDocument>;
 
 export interface DeriveProofOptions {
+  readonly context?: JsonLdContextHeader;
   readonly challenge?: string;
   readonly domain?: string;
   readonly secret?: Uint8Array;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import {
   DiffVCResult,
   DocumentLoader,
   ExpandedJsonldPair,
+  JsonLdContextHeader,
   JsonObject,
   JsonValue,
   VC,
@@ -16,7 +17,9 @@ import {
 } from './types';
 
 const PROOF = 'https://w3id.org/security#proof';
+const VC_CONTEXT = 'https://www.w3.org/2018/credentials/v1';
 const DATA_INTEGRITY_CONTEXT = 'https://www.w3.org/ns/data-integrity/v1';
+const ZKPLD_CONTEXT = 'https://zkp-ld.org/context.jsonld';
 const SKOLEM_PREFIX = 'urn:bnid:';
 const SKOLEM_REGEX = /[<"]urn:bnid:([^>"]+)[>"]/g;
 const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
@@ -485,15 +488,26 @@ export const jsonldProofFromRDF = async (
 /**
  * Converts RDF data representing a Verifiable Presentation (VP) into a JSON-LD Node Object.
  * @param vpRDF The RDF data representing the Verifiable Presentation.
- * @param context The JSON-LD context definition.
  * @param documentLoader The document loader used for resolving external resources.
+ * @param context The JSON-LD context definition to be used in the output JSON-LD VP object.
  * @returns A Promise that resolves to the JSON-LD Node Object representing the Verifiable Presentation.
  */
 export const jsonldVPFromRDF = async (
   vpRDF: string,
-  context: jsonld.ContextDefinition,
   documentLoader: DocumentLoader,
+  context?: JsonLdContextHeader,
 ): Promise<jsonld.NodeObject> => {
+  const defaultContext: (string | jsonld.ContextDefinition)[] = [
+    VC_CONTEXT,
+    DATA_INTEGRITY_CONTEXT,
+    ZKPLD_CONTEXT,
+  ];
+  if (Array.isArray(context)) {
+    defaultContext.push(...context);
+  } else if (context !== undefined) {
+    defaultContext.push(context);
+  }
+
   const vpFrame: jsonld.JsonLdDocument = {
     type: 'VerifiablePresentation',
     proof: {},
@@ -508,7 +522,7 @@ export const jsonldVPFromRDF = async (
       },
     ],
   };
-  vpFrame['@context'] = context;
+  vpFrame['@context'] = defaultContext;
 
   const vpRDFObj = vpRDF as unknown as object;
   const expandedJsonld = await jsonld.fromRDF(vpRDFObj, {

--- a/tests/blindSignatures.spec.ts
+++ b/tests/blindSignatures.spec.ts
@@ -1,4 +1,3 @@
-import * as jsonld from 'jsonld';
 import { describe, expect, test } from 'vitest';
 import {
   requestBlindSign,
@@ -17,9 +16,7 @@ import disclosed1 from './example/disclosed1.json';
 import keypairs from './example/keypairs.json';
 import vcDraft0WithoutCryptosuite from './example/vc0_without_cryptosuite.json';
 import vcDraft1 from './example/vc1.json';
-import _vpContext from './example/vpContext.json';
-
-const vpContext = _vpContext as unknown as jsonld.ContextDefinition;
+import vpContext from './example/vpContext.json';
 
 describe('Blind Signatures', () => {
   test('blind sign and verify', async () => {
@@ -101,9 +98,9 @@ describe('Blind Signatures', () => {
         { original: vc1, disclosed: disclosed1 },
       ],
       keypairs,
-      vpContext,
       localDocumentLoader,
       {
+        context: vpContext,
         challenge: challengeForDeriveProof,
         domain,
         secret,
@@ -145,9 +142,9 @@ describe('Blind Signatures', () => {
       deriveProof(
         [{ original: vc0, disclosed: disclosedBound0 }],
         keypairs,
-        vpContext,
         localDocumentLoader,
         {
+          context: vpContext,
           challenge,
           // secret
         },

--- a/tests/example/vpContext.json
+++ b/tests/example/vpContext.json
@@ -1,8 +1,5 @@
 [
-  "https://www.w3.org/2018/credentials/v1",
-  "https://www.w3.org/ns/data-integrity/v1",
   "https://schema.org/",
-  "https://zkp-ld.org/context.jsonld",
   {
     "isPatientOf": "http://example.org/vocab/isPatientOf",
     "lotNumber": "http://example.org/vocab/lotNumber",

--- a/tests/example/vpContext3.json
+++ b/tests/example/vpContext3.json
@@ -1,7 +1,4 @@
 [
-  "https://www.w3.org/2018/credentials/v1",
-  "https://www.w3.org/ns/data-integrity/v1",
   "https://schema.org/",
-  "https://zkp-ld.org/context.jsonld",
   "https://zkp-ld.org/bbs-termwise-2021.jsonld"
 ]

--- a/tests/example/vpContext4.json
+++ b/tests/example/vpContext4.json
@@ -1,8 +1,5 @@
 [
-  "https://www.w3.org/2018/credentials/v1",
-  "https://www.w3.org/ns/data-integrity/v1",
   "https://schema.org/",
-  "https://zkp-ld.org/context.jsonld",
   {
     "children": {
       "@id": "http://example.org/childrenSet"

--- a/tests/proofs.spec.ts
+++ b/tests/proofs.spec.ts
@@ -37,9 +37,11 @@ describe('Proofs', () => {
         { original: vc1, disclosed: disclosed1 },
       ],
       keypairs,
-      vpContext,
       localDocumentLoader,
-      { challenge },
+      {
+        context: vpContext,
+        challenge,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -57,9 +59,11 @@ describe('Proofs', () => {
     const vp = await deriveProof(
       [{ original: vc3, disclosed: disclosed3 }],
       keypairs,
-      vpContext3,
       remoteDocumentLoader,
-      { challenge },
+      {
+        context: vpContext3,
+        challenge,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -81,9 +85,11 @@ describe('Proofs', () => {
         { original: vc1, disclosed: disclosed1 },
       ],
       keypairs,
-      vpContext,
       localDocumentLoader,
-      { challenge },
+      {
+        context: vpContext,
+        challenge,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -101,9 +107,11 @@ describe('Proofs', () => {
     const vp = await deriveProof(
       [{ original: vc4, disclosed: disclosed4 }],
       keypairs,
-      vpContext4,
       localDocumentLoader,
-      { challenge },
+      {
+        context: vpContext4,
+        challenge,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -157,9 +165,13 @@ describe('Proofs', () => {
     const vp = await deriveProof(
       [{ original: vc2, disclosed: disclosed2 }],
       keypairs,
-      vpContext,
       localDocumentLoader,
-      { challenge, predicates, circuits },
+      {
+        context: vpContext,
+        challenge,
+        predicates,
+        circuits,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -219,9 +231,13 @@ describe('Proofs', () => {
     const vp = await deriveProof(
       [{ original: vc2, disclosed: disclosed2 }],
       keypairs,
-      vpContext,
       localDocumentLoader,
-      { challenge, predicates, circuits },
+      {
+        context: vpContext,
+        challenge,
+        predicates,
+        circuits,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -281,9 +297,13 @@ describe('Proofs', () => {
     const vp = await deriveProof(
       [{ original: vc2, disclosed: disclosed2 }],
       keypairs,
-      vpContext,
       localDocumentLoader,
-      { challenge, predicates, circuits },
+      {
+        context: vpContext,
+        challenge,
+        predicates,
+        circuits,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -377,9 +397,13 @@ describe('Proofs', () => {
         { original: vc1, disclosed: disclosed1 },
       ],
       keypairs,
-      vpContext,
       localDocumentLoader,
-      { challenge, predicates, circuits },
+      {
+        context: vpContext,
+        challenge,
+        predicates,
+        circuits,
+      },
     );
     console.log(`vp:\n${JSON.stringify(vp, null, 2)}`);
     expect(vp).not.toHaveProperty('error');
@@ -405,7 +429,8 @@ describe('Proofs', () => {
     const challenge = 'abcde';
     const domain = 'example.org';
     const secret = new Uint8Array(Buffer.from('SECRET'));
-    const vp = await deriveProof([], keypairs, vpContext, localDocumentLoader, {
+    const vp = await deriveProof([], keypairs, localDocumentLoader, {
+      context: vpContext,
       challenge,
       secret,
       domain,
@@ -427,7 +452,8 @@ describe('Proofs', () => {
     const domain = 'example.org';
     const secret = new Uint8Array(Buffer.from('SECRET'));
     await expect(
-      deriveProof([], keypairs, vpContext, localDocumentLoader, {
+      deriveProof([], keypairs, localDocumentLoader, {
+        context: vpContext,
         challenge,
         secret,
         domain,


### PR DESCRIPTION
**BREAKING**: Make `context` parameter in `deriveProof` optional and add a default value for the VP context.